### PR TITLE
update Filter tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ Functions/Config_dio.fig
 Functions/Frequency readout per trial.asv
 Help_figs/set_DIO.png
 Functions/Help_figs/set_DIO.png
+*.mat
+Functions/noisy_data_generator.m
+Functions/data_generator5.m
+Functions/data_generator4.m

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Functions/Config_dio.fig
 Functions/Frequency readout per trial.asv
 Help_figs/set_DIO.png
 Functions/Help_figs/set_DIO.png
+*.mat

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,3 @@ Functions/Config_dio.fig
 Functions/Frequency readout per trial.asv
 Help_figs/set_DIO.png
 Functions/Help_figs/set_DIO.png
-*.mat
-Functions/noisy_data_generator.m
-Functions/data_generator5.m
-Functions/data_generator4.m

--- a/Functions/FilterTool/filters.m
+++ b/Functions/FilterTool/filters.m
@@ -72,6 +72,7 @@ global l1; global h1;
 global filter_data; 
 global Fs; Fs = 256;
 global power;
+power = [];
 global stop_on; global pass_on; global plot_on;
 l1 = str2double(get(handles.l1,'String'));
 h1 = str2double(get(handles.h1,'String'));
@@ -192,7 +193,7 @@ curdir = cd;
 cd([curdir filesep 'Data']);
 uisave({'data'},'Name');
 cd(curdir);
-clear filename; clear data; clear filter_data;
+clear filename; clear data; clearvars -global filter_data;
 str = ' ';
 set(handles.fi_name,'string',str);
 set(handles.fi_size,'string',str);
@@ -200,7 +201,7 @@ curdir = cd;
 cd([curdir filesep 'Data']);
 uisave({'power'},'Power');
 cd(curdir);
-clear power;
+clearvars -global power
 
 % --------------------------------------------------------------------
 function help_Callback(hObject, eventdata, handles)


### PR DESCRIPTION
Fix for a long-known bug that power values remain in the Filter tool workspace when filtering a new file. 
- initiate empty power variablee before filtering
- clear global power variable after saving.